### PR TITLE
Fix not working link for udemy course

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This structured learning path guides you through the essential steps required to
    - [The C Programming Language (ANSI C) by Brian Kernighan and Dennis Ritchie](https://www.amazon.com/Programming-Language-2nd-Brian-Kernighan/dp/0131103628)
    - Practicing C programming [GPT-2 from Scratch in C - Part 1](https://youtu.be/d1LNUvkRMEg?si=j265w0Hoje-rxfrN) and [GPT-2 from Scratch in C - Part 2](https://youtu.be/j-kMKBQ1vkw?si=iGtmMMLi5DfMlvXf)
    - 🇵🇱 [Podstawy programowania. Język C](https://www.udemy.com/course/podstawy-programowania-jezyk-c)  
-   - 🇵🇱 [Zaawansowane programowanie w języku C](https://www.udemy.com/course/zaawansowane-programowanie-jezyku-c)  
+   - 🇵🇱 [Zaawansowane programowanie w języku C](https://www.udemy.com/course/zaawansowane-programowanie-w-jezyku-c/)  
 
 2. **Data Structures**:  
    Learn essential data structures and algorithms, a prerequisite for effective problem-solving and programming.  


### PR DESCRIPTION
The link for "Zaawansowane programowanie w języku C" was invalid and was redirecting to 404 udemy page.

## Summary by Sourcery

Bug Fixes:
- Corrected the Udemy course link for "Zaawansowane programowanie w języku C" to resolve a 404 error.